### PR TITLE
Specify speed on turns

### DIFF
--- a/robot/Car.ts
+++ b/robot/Car.ts
@@ -25,12 +25,14 @@ export default function (motors: {left: Motor, right: Motor}) {
       ])
     },
 
-    stop() {
+    async stop() {
       motors.left.stop()
       motors.right.stop()
+      await wait(100)
+      this.float()
     },
 
-    float() {
+    async float() {
       motors.left.float()
       motors.right.float()
     },

--- a/robot/Car.ts
+++ b/robot/Car.ts
@@ -48,10 +48,11 @@ export default function (motors: {left: Motor, right: Motor}) {
       const other = motors[direction]
       if (onTheSpot) {
         await Promise.all([motor.accelerate(-speed), other.accelerate(speed)])
+        await wait(2.16 * degrees)
       } else {
         await Promise.all([motor.float(), other.accelerate(speed)])
+        await wait(18.5 * degrees)
       }
-      await wait(18.5 * degrees)
       await Promise.all([motor.float(), other.float()])
     },
   }

--- a/robot/Car.ts
+++ b/robot/Car.ts
@@ -36,20 +36,18 @@ export default function (motors: {left: Motor, right: Motor}) {
     },
 
     /*
-      Turn the car in the given direction to a given degree.
+      Turn the car in the given direction to a given degree in a given speed.
       If 'onTheSpot' is set true, the wheels will turn in different directions.
     */
-    async turn(degrees: number, direction: Direction, onTheSpot = false) {
+    async turn(degrees: number, direction: Direction, speed: number, onTheSpot = false) {
       const motor = motors[otherDirection(direction)]
-      const currentSpeed = motor.speed
       if (onTheSpot) {
-        motor.float()
-        await motor.accelerate(-currentSpeed)
+        await motor.accelerate(-speed)
       } else {
         motor.float()
       }
       await wait(18.5 * degrees)
-      await motor.accelerate(currentSpeed)
+      await motor.accelerate(speed)
     },
   }
 }

--- a/robot/index.ts
+++ b/robot/index.ts
@@ -12,22 +12,27 @@ async function loop() {
   car.accelerate(50)
   await wait(500)
   console.log('turn left 180°')
-  await car.turn(180, Direction.left)
+  await car.turn(180, Direction.left, 50)
   console.log('turn left 180° on the spot')
-  await car.turn(180, Direction.left, true)
+  await car.turn(180, Direction.left, 50, true)
   console.log('turn right 180°')
-  await car.turn(180, Direction.right)
+  await car.turn(180, Direction.right, 50)
   console.log('turn right 180° on the spot')
-  await car.turn(180, Direction.right, true)
+  await car.turn(180, Direction.right, 50, true)
   car.stop()
   console.log('end of loop')
   // setImmediate(loop)
 }
 
-loop()
+async function turnOnSpot() {
+  await car.turn(360, Direction.left, 100, true)
+}
+
+turnOnSpot()
 
 process.on('SIGINT', function() {
   console.log("Caught interrupt signal")
   car.stop()
+  car.float()
   process.exit()
 })

--- a/robot/index.ts
+++ b/robot/index.ts
@@ -8,27 +8,21 @@ const motor2 = Motor(17, 27, 22)
 const car = Car({ left: motor1, right: motor2 })
 
 async function loop() {
-  console.log('starting loop')
-  car.accelerate(50)
-  await wait(500)
-  console.log('turn left 180°')
-  await car.turn(180, Direction.left, 50)
+  console.log('turn left 45°')
+  await car.turn(45, Direction.left, 50)
+  console.log('turn right 270°')
+  await car.turn(270, Direction.right, 50)
+  console.log('turn left 45°')
+  await car.turn(45, Direction.left, 50)
   console.log('turn left 180° on the spot')
   await car.turn(180, Direction.left, 50, true)
-  console.log('turn right 180°')
-  await car.turn(180, Direction.right, 50)
-  console.log('turn right 180° on the spot')
-  await car.turn(180, Direction.right, 50, true)
-  car.stop()
-  console.log('end of loop')
-  // setImmediate(loop)
 }
 
 async function turnOnSpot() {
   await car.turn(360, Direction.left, 100, true)
 }
 
-turnOnSpot().then(car.stop)
+loop().then(car.stop)
 
 process.on('SIGINT', function() {
   console.log("Caught interrupt signal")

--- a/robot/index.ts
+++ b/robot/index.ts
@@ -28,7 +28,7 @@ async function turnOnSpot() {
   await car.turn(360, Direction.left, 100, true)
 }
 
-turnOnSpot()
+turnOnSpot().then(car.stop)
 
 process.on('SIGINT', function() {
   console.log("Caught interrupt signal")


### PR DESCRIPTION
Previously, it was necessary to run the car to be able to turn it. It used the current speed for turning as well.
With this change, you need to specify the turning speed as well, so it can start right away turning.